### PR TITLE
Move dependencies to devDependencies, update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,8 @@
   },
   "homepage": "https://github.com/ipatate/react-router-scroll-memory#readme",
   "peerDependencies": {
-    "react": "15.x",
-    "react-router-dom": "4.x"
-  },
-  "dependencies": {
-    "react": "^16.6.0",
-    "react-router-dom": "^4.3.1"
+    "react": ">=15.x",
+    "react-router-dom": ">=4.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",
@@ -66,6 +62,8 @@
     "husky": "^1.1.3",
     "jest": "^23.6.0",
     "lint-staged": "^8.0.4",
+    "react": "^16.6.0",
+    "react-router-dom": "^4.3.1",
     "react-test-renderer": "^16.6.0",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-node-resolve": "^3.4.0",


### PR DESCRIPTION
Should be relying on `peerDependencies` for `react` and `react-router-dom` instead of forcing a specific version to be installed. Should fix #18 