### PR TITLE
Reduce NPM deployed package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "scroll",
     "history"
   ],
+  "files":["dist"],
   "author": "Faramaz Patrick",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
The deployed package size is quite large for this package.
![image](https://user-images.githubusercontent.com/1157086/78926487-ffc10180-7a51-11ea-85da-2e3d51427e8c.png)

But the actual source code is quite small:
![image](https://user-images.githubusercontent.com/1157086/78926511-0bacc380-7a52-11ea-9072-d5b719dd855b.png)

Most of the size comes from things, like tests and gifs that aren't needed to be sent to consumers: https://unpkg.com/browse/react-router-scroll-memory@2.0.5/

This should fix that by only deploying the minimal set of things to make this package work.